### PR TITLE
Upgraded node-hid dependency to 0.4.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "bluebird": "^2.9.14",
     "lodash": "^2.4.1",
-    "node-hid": "^0.3.2"
+    "node-hid": "^0.4.0"
   }
 }


### PR DESCRIPTION
Upgraded node-hid dependency to 0.4.0 since this is meant to work with node 0.12.x
For further information on the fix see https://github.com/node-hid/node-hid/pull/95
